### PR TITLE
feat: ask 명령에 --file 인자 지원 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ reply = openai_llm.ask("안녕하세요!")
 openai_llm = OpenAILLM(model="gpt-4o-mini", api_key="your-api-key")
 
 # Anthropic (ANTHROPIC_API_KEY 환경변수 필요)
-claude_llm = AnthropicLLM(model="claude-3-haiku-20240307")
+claude_llm = AnthropicLLM(model="claude-3-5-haiku-latest")
 reply = claude_llm.ask("안녕하세요!")
 
 # Google (GOOGLE_API_KEY 환경변수 필요)
@@ -644,10 +644,10 @@ llm = GoogleLLM(api_key="your-api-key")
 pyhub-llm chat
 
 # 특정 모델로 채팅
-pyhub-llm chat --model claude-3-haiku-20240307
+pyhub-llm chat --model claude-3-5-haiku-latest
 
 # 시스템 프롬프트 설정
-pyhub-llm chat --system "당신은 파이썬 전문가입니다"
+pyhub-llm chat --system-prompt "당신은 파이썬 전문가입니다"
 ```
 
 ### 단일 질문
@@ -655,8 +655,17 @@ pyhub-llm chat --system "당신은 파이썬 전문가입니다"
 # 질문하고 응답 받기
 pyhub-llm ask "Python과 Go의 차이점은?"
 
-# 파일 내용과 함께 질문
+# 파일 내용과 함께 질문 (--file 옵션)
 pyhub-llm ask "이 코드를 리뷰해주세요" --file main.py
+
+# 여러 파일과 함께 질문
+pyhub-llm ask "이 파일들의 관계를 설명해주세요" --file main.py --file utils.py
+
+# stdin으로 파일 내용 전달
+cat main.py | pyhub-llm ask "이 코드를 리뷰해주세요"
+
+# --context 옵션으로 파일 내용 전달
+pyhub-llm ask "이 코드를 리뷰해주세요" --context "$(cat main.py)"
 ```
 
 ### 이미지 설명
@@ -879,4 +888,3 @@ if len(llm) > 10:
 - [PyPI](https://pypi.org/project/pyhub-llm)
 - [GitHub](https://github.com/pyhub-kr/pyhub-llm)
 - [이슈 트래커](https://github.com/pyhub-kr/pyhub-llm/issues)
-

--- a/src/pyhub/llm/__main__.py
+++ b/src/pyhub/llm/__main__.py
@@ -1,4 +1,10 @@
 from pyhub.llm.commands import app
 
-if __name__ == "__main__":
+
+def main():
+    """Entry point for the CLI."""
     app()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ask_file_argument.py
+++ b/tests/test_ask_file_argument.py
@@ -1,0 +1,105 @@
+"""Tests for ask command --file argument"""
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import typer.testing
+from pyhub.llm.commands import app
+
+
+def test_ask_with_single_file():
+    """Test ask command with single file"""
+    runner = typer.testing.CliRunner()
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write("def hello():\n    return 'world'")
+        temp_file = Path(f.name)
+    
+    try:
+        with patch('pyhub.llm.LLM.create') as mock_create:
+            # Mock the LLM response
+            mock_llm = mock_create.return_value
+            mock_response = type('Response', (), {'text': 'Test response', 'usage': None})
+            mock_llm.ask.return_value = mock_response
+            
+            result = runner.invoke(
+                app, 
+                ["ask", "분석해주세요", "--file", str(temp_file), "--no-stream"]
+            )
+            
+            assert result.exit_code == 0
+            assert "Test response" in result.output
+            
+            # Verify that the file content was passed as context
+            call_args = mock_llm.ask.call_args
+            assert call_args is not None
+    finally:
+        temp_file.unlink()
+
+
+def test_ask_with_multiple_files():
+    """Test ask command with multiple files"""
+    runner = typer.testing.CliRunner()
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f1, \
+         tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f2:
+        f1.write("def add(a, b):\n    return a + b")
+        f2.write("def multiply(a, b):\n    return a * b")
+        temp_file1 = Path(f1.name)
+        temp_file2 = Path(f2.name)
+    
+    try:
+        with patch('pyhub.llm.LLM.create') as mock_create:
+            # Mock the LLM response
+            mock_llm = mock_create.return_value
+            mock_response = type('Response', (), {'text': 'Test response', 'usage': None})
+            mock_llm.ask.return_value = mock_response
+            
+            result = runner.invoke(
+                app, 
+                ["ask", "분석해주세요", "--file", str(temp_file1), "--file", str(temp_file2), "--no-stream"]
+            )
+            
+            assert result.exit_code == 0
+            assert "Test response" in result.output
+    finally:
+        temp_file1.unlink()
+        temp_file2.unlink()
+
+
+def test_ask_with_nonexistent_file():
+    """Test ask command with nonexistent file"""
+    runner = typer.testing.CliRunner()
+    
+    result = runner.invoke(
+        app, 
+        ["ask", "분석해주세요", "--file", "nonexistent_file.py"]
+    )
+    
+    assert result.exit_code == 1
+    assert "오류: 파일을 찾을 수 없습니다" in result.output
+
+
+def test_ask_with_file_and_context():
+    """Test ask command with both file and context options"""
+    runner = typer.testing.CliRunner()
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
+        f.write("def hello():\n    return 'world'")
+        temp_file = Path(f.name)
+    
+    try:
+        with patch('pyhub.llm.LLM.create') as mock_create:
+            # Mock the LLM response
+            mock_llm = mock_create.return_value
+            mock_response = type('Response', (), {'text': 'Test response', 'usage': None})
+            mock_llm.ask.return_value = mock_response
+            
+            result = runner.invoke(
+                app, 
+                ["ask", "분석해주세요", "--file", str(temp_file), "--context", "추가 컨텍스트", "--no-stream"]
+            )
+            
+            assert result.exit_code == 0
+            assert "Test response" in result.output
+    finally:
+        temp_file.unlink()


### PR DESCRIPTION
## Summary
- ask 명령에서 `--file` 인자를 지원하여 파일 내용을 쉽게 전달할 수 있도록 개선
- README.md에 명시된 예시 코드가 실제로 동작하도록 구현

## Changes
- **--file 옵션 추가**
  - 단일 파일: `--file main.py`
  - 여러 파일: `--file main.py --file utils.py`
  - 파일 내용을 자동으로 context에 추가
  
- **기존 옵션과의 호환성**
  - stdin, --context와 함께 사용 가능
  - 여러 소스의 context를 자동으로 병합
  
- **문서 개선**
  - README.md에 다양한 파일 사용 예시 추가
  - stdin, --context 사용법도 함께 문서화

## Test plan
- [x] 단일 파일 읽기 테스트
- [x] 여러 파일 읽기 테스트  
- [x] 존재하지 않는 파일 에러 처리 테스트
- [x] --file과 --context 조합 테스트

Fixes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying one or more files as additional context in the CLI ask command.
  - Enhanced CLI usage documentation with new examples and updated options.

- **Bug Fixes**
  - Improved error handling for missing or unreadable files in the CLI.

- **Documentation**
  - Updated README to reflect the latest model version, revised CLI options, and added detailed usage examples.

- **Tests**
  - Introduced comprehensive tests for the new file input feature in the ask command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->