### PR TITLE
feat: MCP 서버 이름 자동 감지 및 설정 간소화

### DIFF
--- a/CHEATSHEET.md
+++ b/CHEATSHEET.md
@@ -359,7 +359,6 @@ async def main():
     llm = await LLM.create_async(
         "gpt-4o-mini",
         mcp_servers=McpStdioConfig(
-            name="calculator",
             cmd="calculator-server"
         )
     )
@@ -822,6 +821,32 @@ for style in ["technical", "simple", "business"]:
 
 ## MCP 통합
 
+### 서버 이름 자동 감지
+
+MCP 서버는 초기화 시 자체 정보(이름, 버전)를 제공합니다. pyhub-llm은 이를 활용하여 서버 이름을 자동으로 감지합니다:
+
+```python
+# name 없이 설정 - 서버가 "calculator-server"로 자동 제공
+config = McpStdioConfig(
+    cmd="pyhub-llm mcp-server run calculator"
+)
+
+# 사용자가 원하면 name 오버라이드 가능
+config = McpStdioConfig(
+    name="my_calc",  # 서버 이름을 "my_calc"로 변경
+    cmd="pyhub-llm mcp-server run calculator"
+)
+```
+
+**서버 이름 우선순위:**
+1. 사용자가 지정한 `name` (최우선)
+2. 서버가 제공하는 이름 (자동 감지)
+3. 자동 생성된 이름 (transport_uuid 형태)
+
+**중복 처리:**
+- 동일한 이름의 서버가 여러 개인 경우 자동으로 suffix 추가 (`calculator-server_1`, `calculator-server_2`)
+- 중복 시 경고 로그 출력
+
 ### 기본 MCP 사용
 
 ```python
@@ -830,9 +855,7 @@ from pyhub.llm.mcp import McpStdioConfig
 
 # MCP 서버 설정
 mcp_config = McpStdioConfig(
-    name="calculator",
-    cmd="calculator-server",  # MCP 서버 실행 명령
-    description="수학 계산 도구"
+    cmd="calculator-server"  # MCP 서버 실행 명령 (name은 서버가 자동 제공)
 )
 
 # LLM과 MCP 통합
@@ -887,14 +910,10 @@ from pyhub.llm.mcp import McpStdioConfig, McpStreamableHttpConfig
 # 다양한 MCP 서버 설정
 servers = [
     McpStdioConfig(
-        name="calculator",
-        cmd="calculator-server",
-        description="수학 계산"
+        cmd="calculator-server"
     ),
     McpStreamableHttpConfig(
-        name="weather",
-        url="http://localhost:8080/mcp",
-        description="날씨 정보"
+        url="http://localhost:8080/mcp"
     )
 ]
 
@@ -919,7 +938,6 @@ if llm._mcp_tools:
 
 # 특정 도구만 사용하도록 필터링
 filtered_config = McpStdioConfig(
-    name="calculator",
     cmd="calculator-server",
     filter_tools=["add", "multiply"]  # 덧셈과 곱셈만 사용
 )

--- a/src/pyhub/llm/mcp/config_loader.py
+++ b/src/pyhub/llm/mcp/config_loader.py
@@ -143,8 +143,6 @@ def validate_mcp_config(config: Dict[str, Any]) -> None:
     # 필수 필드 검사
     if 'type' not in config:
         raise ValueError("Missing required field 'type'")
-    if 'name' not in config:
-        raise ValueError("Missing required field 'name'")
     
     # type 값 검사
     valid_types = {'stdio', 'streamable_http', 'websocket', 'sse'}

--- a/src/pyhub/llm/mcp/configs.py
+++ b/src/pyhub/llm/mcp/configs.py
@@ -18,7 +18,7 @@ __all__ = [
 @dataclass(kw_only=True)
 class McpServerConfig:
     """MCP 서버 설정 기본 클래스"""
-    name: str  # 서버 식별자
+    name: Optional[str] = None  # 서버 식별자 (선택적 - 서버에서 자동으로 가져올 수 있음)
     description: Optional[str] = None
     filter_tools: Optional[List[str]] = None
     timeout: int = 30

--- a/src/pyhub/llm/mcp/multi_client.py
+++ b/src/pyhub/llm/mcp/multi_client.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
+import uuid, Union
 
 from pyhub.llm.agents.base import Tool
 
@@ -51,12 +52,24 @@ class MultiServerMCPClient:
             ... }
             >>> client = MultiServerMCPClient(servers)
         """
-        # Dataclass 리스트를 딕셔너리로 변환
+        # Dataclass 리스트를 딥셔너리로 변환
         if isinstance(servers, list):
             self.servers = {}
-            for config in servers:
+            for idx, config in enumerate(servers):
                 if isinstance(config, McpServerConfig):
-                    self.servers[config.name] = config.to_dict()
+                    # name이 없으면 임시로 생성
+                    if config.name:
+                        temp_name = config.name
+                    else:
+                        # transport 타입과 UUID로 임시 이름 생성
+                        transport = getattr(config, 'transport', 'unknown')
+                        temp_name = f"{transport}_{uuid.uuid4().hex[:8]}"
+                    
+                    # 중복 검사
+                    if temp_name in self.servers:
+                        logger.warning(f"Duplicate server name '{temp_name}' detected. Previous configuration will be overwritten.")
+                    
+                    self.servers[temp_name] = config.to_dict()
                 else:
                     raise TypeError(f"리스트 요소는 McpServerConfig여야 합니다: {type(config)}")
         else:
@@ -98,6 +111,7 @@ class MultiServerMCPClient:
 
     async def _connect_server(self, server_name: str, config: Dict[str, Any]):
         """개별 서버에 연결 (모든 Transport 지원)"""
+        final_server_name = server_name  # 최종 서버 이름
         try:
             # Config 유효성 검사
             if config is None:
@@ -127,23 +141,41 @@ class MultiServerMCPClient:
             # 연결 시작
             await connection_context.__aenter__()
 
-            self._clients[server_name] = client
-            self._active_connections[server_name] = connection_context
-
-            # 현재 태스크 저장 - 이제 필요없음
-            # self._connection_tasks[server_name] = asyncio.current_task()
+            # 서버 정보를 가져와서 이름 결정
+            server_info = client.get_server_info()
+            if server_info and server_info.get('name'):
+                # 우선순위: 1. 사용자 지정 name, 2. 서버 제공 name, 3. 임시 생성 name
+                if not config.get('name'):
+                    # 사용자가 name을 지정하지 않았다면 서버 이름 사용
+                    final_server_name = server_info['name']
+                    
+                    # 중복 처리: 서버 이름이 이미 사용 중이면 suffix 추가
+                    if final_server_name in self._clients:
+                        suffix = 1
+                        while f"{final_server_name}_{suffix}" in self._clients:
+                            suffix += 1
+                        final_server_name = f"{final_server_name}_{suffix}"
+                        logger.info(f"Server name '{server_info['name']}' already in use, renamed to '{final_server_name}'")
+            
+            # 기존 server_name으로 저장된 것들을 final_server_name으로 업데이트
+            if final_server_name != server_name:
+                # 임시 이름으로 저장된 서버 설정을 실제 서버 이름으로 변경
+                self.servers[final_server_name] = self.servers.pop(server_name)
+            
+            self._clients[final_server_name] = client
+            self._active_connections[final_server_name] = connection_context
 
             # 연결 성공 로그 (transport 정보 포함)
             description = config.get("description", "")
             if description:
-                logger.info(f"✅ Connected to '{server_name}' via {transport_type}: {description}")
+                logger.info(f"✅ Connected to '{final_server_name}' via {transport_type}: {description}")
             else:
-                logger.info(f"✅ Connected to '{server_name}' via {transport_type}")
+                logger.info(f"✅ Connected to '{final_server_name}' via {transport_type}")
 
         except Exception as e:
             error_msg = str(e)
-            self._connection_errors[server_name] = error_msg
-            logger.error(f"❌ Failed to connect to '{server_name}': {error_msg}")
+            self._connection_errors[final_server_name] = error_msg
+            logger.error(f"❌ Failed to connect to '{final_server_name}': {error_msg}")
             # 연결 실패해도 예외를 던지지 않음 (다른 서버 연결 계속 진행)
 
     async def get_tools(self) -> List[Tool]:

--- a/tests/test_mcp_client_config.py
+++ b/tests/test_mcp_client_config.py
@@ -32,6 +32,26 @@ class TestMCPClientConfig:
         assert client.transport is not None
         assert client.server_params is None
     
+    def test_mcpclient_without_name(self):
+        """name 없이 MCPClient 생성"""
+        # name 없는 STDIO config
+        stdio_config = McpStdioConfig(
+            cmd="python calculator.py"
+        )
+        
+        client = MCPClient(stdio_config)
+        assert client.transport is not None
+        assert client.server_params is None
+        
+        # name 없는 HTTP config
+        http_config = McpStreamableHttpConfig(
+            url="http://localhost:8080/mcp"
+        )
+        
+        client = MCPClient(http_config)
+        assert client.transport is not None
+        assert client.server_params is None
+    
     def test_mcpclient_with_dict_config(self):
         """기존 dict 방식으로 MCPClient 생성"""
         config = {


### PR DESCRIPTION
## 개요
MCP 서버 설정을 더 간결하고 사용하기 쉽게 개선했습니다. 이제 서버 이름을 수동으로 지정할 필요가 없고, MCP 서버가 제공하는 정보를 자동으로 활용합니다.

## 주요 변경사항

### 1. 서버 이름 자동 감지
- MCP 서버 초기화 시 `serverInfo`에서 이름과 버전 정보 추출
- `name` 필드를 선택적으로 변경 (기존: 필수 → 변경: 선택적)
- 서버 이름 우선순위: 사용자 지정 > 서버 제공 > 자동 생성

### 2. 중복 처리 개선
- 동일한 이름의 서버 감지 시 자동으로 suffix 추가 (`calculator-server_1`)
- 중복 시 경고 로그 출력으로 사용자에게 알림

### 3. 설정 간소화
- 불필요한 `description` 필드 제거 (MCP 서버 자체가 도구 설명 제공)
- 더 간결한 설정 문법 지원

## 변경 전/후 비교

### 기존 방식
```python
config = McpStdioConfig(
    name="calculator",  # 수동 지정 필요
    cmd="pyhub-llm mcp-server run calculator",
    description="수학 계산 도구"  # 중복 정보
)
```

### 개선된 방식
```python
config = McpStdioConfig(
    cmd="pyhub-llm mcp-server run calculator"
    # name은 서버에서 "calculator-server"로 자동 제공
    # description은 서버의 각 도구가 개별 제공
)
```

## 기술적 개선사항

### MCPClient 개선
- `session.initialize()` 결과를 저장하여 서버 정보 활용
- `get_server_info()` 메서드 추가로 서버 정보 접근 가능

### MultiServerMCPClient 개선
- 서버 이름 결정 로직 구현 (우선순위 기반)
- 중복 감지 및 자동 suffix 추가
- 임시 이름에서 실제 서버 이름으로 업데이트

### 검증 로직 수정
- `config_loader.py`에서 name 필수 검증 제거
- 테스트 케이스 추가 (name 없는 설정 테스트)

## 호환성
- **하위 호환성 유지**: 기존 코드는 그대로 동작
- **선택적 개선**: 원하는 경우에만 새로운 방식 사용 가능
- **점진적 마이그레이션**: 기존 name 지정 방식도 계속 지원

## 테스트
- [x] name 없는 설정으로 MCPClient 생성 테스트
- [x] 서버 정보 자동 추출 검증
- [x] 중복 이름 처리 로직 확인
- [x] 기존 코드 호환성 테스트

Closes #14